### PR TITLE
Update brave-bin-1.26.63.ebuild

### DIFF
--- a/www-client/brave-bin/brave-bin-1.26.63.ebuild
+++ b/www-client/brave-bin/brave-bin-1.26.63.ebuild
@@ -57,7 +57,7 @@ RDEPEND="
 	app-accessibility/at-spi2-atk
 	x11-libs/gtk+
 	x11-libs/gdk-pixbuf
-	virtual/libffi
+	dev-libs/libffi
 	dev-libs/libpcre
 	net-libs/gnutls
 	sys-libs/zlib


### PR DESCRIPTION
deprecate virtual/libffi in favour of dev-libs/libffi